### PR TITLE
Handle OSV scan findings without failing workflow

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -28,7 +28,10 @@ jobs:
         run: go install github.com/google/osv-scanner/cmd/osv-scanner@latest
 
       - name: Run OSV scan
+        # OSV-Scanner returns exit code 1 when vulnerabilities are found; allow the
+        # workflow to continue so we can still upload the SARIF results.
         run: ~/go/bin/osv-scanner --lockfile=yarn.lock --format sarif --output osv.sarif
+        continue-on-error: true
 
       - name: Upload OSV SARIF
         uses: github/codeql-action/upload-sarif@v3


### PR DESCRIPTION
## Summary
- allow the OSV scan step to continue when vulnerabilities are reported so SARIF still uploads
- document why the step is allowed to proceed despite a non-zero exit code

## Testing
- not run (not needed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692a1030b6848324bbf93ad15ca5bcc5)